### PR TITLE
fix(build): add packages field to pnpm-workspace for Vercel pnpm install

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,5 @@
+packages:
+  - "*"
+
 ignoredBuiltDependencies:
   - libpq


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Add wildcard packages field to pnpm-workspace.yaml to ensure Vercel includes all packages during install